### PR TITLE
Exclude example

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,9 @@ remote_theme: "just-the-docs/just-the-docs"
 plugins:
   - jekyll-feed
 
+exclude:
+  - examples/
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,10 @@ plugins:
 
 exclude:
   - examples/
+  
+include:
+  - examples/examples.md
+  - examples/minimalexample/README.md
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Examples
+permalink: /examples/
+has_children: true
+nav_order: 9002
+---
+# Examples
+
+What the title says.

--- a/examples/minimalexample/README.md
+++ b/examples/minimalexample/README.md
@@ -3,8 +3,6 @@ layout: page
 parent: Examples
 title: Minimal Example
 permalink: /examples/minimalExample/
-nav_order: 2
-has_children: true
 ---
 # MinimalExample
 

--- a/examples/minimalexample/README.md
+++ b/examples/minimalexample/README.md
@@ -1,3 +1,11 @@
+---
+layout: page
+parent: Examples
+title: Minimal Example
+permalink: /examples/minimalExample/
+nav_order: 2
+has_children: true
+---
 # MinimalExample
 
 Minimal might be a bit misleading. It used to be, though. 

--- a/tutorial.markdown
+++ b/tutorial.markdown
@@ -2,6 +2,7 @@
 layout: page
 title: Tutorial
 permalink: /tutorial/
+nav_order: 9001
 ---
 
 # Tutorial


### PR DESCRIPTION
Current Behaviour : 
* README.md of minimalExample is displayed in the generated documentation, at top level navigtion
* in the locally generate documentation, i could also access all non-markdown files in the minimalexample  

New Behaviour : 
* README.md of minimalExample got a decent header and position in the navigation.
* other files of minimalExample are exluded, just in case.