### PR TITLE
contributors and ordering of pages

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -7,14 +7,17 @@ permalink: /contributors/
 
 # Contributors
 
-Slingshot is a development project in Palladio that enhances the simulation and adds new modelling capabilities to Palladio.
-Slingshot started at the Software Quality and Architecture (SQA) group at the University of Stuttgart.  
+Slingshot is a software development project in Palladio that enhances the simulation and adds new modelling capabilities to Palladio.
+Slingshot started at the Software Quality and Architecture (SQA) group which is part of the Institute of Software Engineering (ISTE) at the University of Stuttgart.  
 
-## Active Contributors
+## Main Contributors
 
 * Steffen Becker (Head, SQA), steffen.becker@iste.uni-stuttgart.de
 * Floriment Klinaku (Research Assistant, SQA), klinaku@iste.uni-stuttgart.de
 * Sarah Stieß  (Research Assistant, SQA), sarah.stiess@iste.uni-stuttgart.de
 * Julijan Katić (Student Assistant, SQA), st154933@stud.uni-stuttgart.de
 
-## Contributors
+## Other Contributors
+
+* Benjamin Hahn
+* Tim Summerer

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Contributors
+nav_order: 6
+permalink: /contributors/
+---
+
+# Contributors
+
+Slingshot is a development project in Palladio that enhances the simulation and adds new modelling capabilities to Palladio.
+Slingshot started at the Software Quality and Architecture (SQA) group at the University of Stuttgart.  
+
+## Active Contributors
+
+* Steffen Becker (Head, SQA), steffen.becker@iste.uni-stuttgart.de
+* Floriment Klinaku (Research Assistant, SQA), klinaku@iste.uni-stuttgart.de
+* Sarah Stieß  (Research Assistant, SQA), stiess@iste.uni-stuttgart.de
+* Julijan Katić (Student Assistant, SQA), st154933@stud.uni-stuttgart.de
+
+## Contributors

--- a/contributors.md
+++ b/contributors.md
@@ -14,7 +14,7 @@ Slingshot started at the Software Quality and Architecture (SQA) group at the Un
 
 * Steffen Becker (Head, SQA), steffen.becker@iste.uni-stuttgart.de
 * Floriment Klinaku (Research Assistant, SQA), klinaku@iste.uni-stuttgart.de
-* Sarah Stieß  (Research Assistant, SQA), stiess@iste.uni-stuttgart.de
+* Sarah Stieß  (Research Assistant, SQA), sarah.stiess@iste.uni-stuttgart.de
 * Julijan Katić (Student Assistant, SQA), st154933@stud.uni-stuttgart.de
 
 ## Contributors

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -3,7 +3,7 @@ layout: page
 title: Examples
 permalink: /examples/
 has_children: true
-nav_order: 9002
+nav_order: 5
 ---
 # Examples
 

--- a/slingshot-simulator/slingshot-framework.markdown
+++ b/slingshot-simulator/slingshot-framework.markdown
@@ -3,7 +3,7 @@ layout: page
 title: Slingshot Simulator
 permalink: /slingshot-simulator/
 has_children: true
-nav_order: 10
+nav_order: 2
 ---
 # Slingshot Simulator
 

--- a/spds/spd.markdown
+++ b/spds/spd.markdown
@@ -3,7 +3,7 @@ layout: page
 title: SPD Language
 permalink: /spd/
 has_children: true
-nav_order: 2
+nav_order: 1
 ---
 # Overview
 

--- a/tutorial-dev.markdown
+++ b/tutorial-dev.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: Developer Tutorial
 permalink: /tutorial-dev/
-nav_order: 60
+nav_order: 4
 ---
 
 # Developer Tutorial

--- a/tutorial-usage.markdown
+++ b/tutorial-usage.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: Usage Tutorial
 permalink: /tutorial-usage/
-nav_order: 50
+nav_order: 3
 ---
 
 # Usage Tutorial


### PR DESCRIPTION
This commit adds a contributors page to the site. It gives some general information about the context of the project.

In addition, it provides a list of active contributors and contributors. I am awaiting replies from some students to confirm whether they want to be part of the list. We can also add a one-liner on what the contributions were, maybe it would also serve us as a log. 

This is a draft for now.